### PR TITLE
update parser options

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,9 @@ module.exports = {
         './rules/eslint-plugin-flowtype',
     ].map(require.resolve),
     parserOptions: {
-        ecmaVersion: 2017,
+        ecmaVersion: 2018,
         sourceType: 'module',
         ecmaFeatures: {
-            experimentalObjectRestSpread: true,
             jsx: true
         },
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimax-javascript",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Optimax JavaScript Style Guide",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Rest/spread operator has gone to specification, so we need to update our config.
https://eslint.org/docs/user-guide/migrating-to-5.0.0#-the-experimentalobjectrestspread-option-has-been-deprecated